### PR TITLE
Spark 3.5.3 Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Start from a Debian base image
-FROM openjdk:8-jre-slim
+FROM openjdk:11-jre-slim
 
 # Set this manually before building the image, requires a local build of the jar
 
-ENV CHRONON_JAR_PATH=spark/target-embedded/scala-2.12/your_build.jar
+ENV CHRONON_JAR_PATH=spark/target-embedded/scala-2.12/spark_embedded-assembly-spark-upgrade-0.0.87-SNAPSHOT.jar
 
 # Update package lists and install necessary tools
 RUN apt-get update && apt-get install -y \
@@ -43,8 +43,8 @@ ENV PATH=${PATH}:${SCALA_HOME}/bin
 # Optional env variables
 ENV SPARK_HOME=${SPARK_HOME:-"/opt/spark"}
 ENV HADOOP_HOME=${HADOOP_HOME:-"/opt/hadoop"}
-ENV SPARK_VERSION=${SPARK_VERSION:-"3.1.1"}
-ENV HADOOP_VERSION=${HADOOP_VERSION:-"3.2"}
+ENV SPARK_VERSION=${SPARK_VERSION:-"3.5.3"}
+ENV HADOOP_VERSION=${HADOOP_VERSION:-"3"}
 RUN mkdir -p ${HADOOP_HOME} && mkdir -p ${SPARK_HOME}
 RUN mkdir -p /opt/spark/spark-events
 WORKDIR ${SPARK_HOME}
@@ -71,7 +71,7 @@ RUN chmod u+x /opt/spark/sbin/* && \
 ENV PYTHONPATH=$SPARK_HOME/python/:/srv/chronon/:$PYTHONPATH
 
 # If trying a standalone docker cluster
-WORKDIR ${SPARK_HOME}
+#WORKDIR ${SPARK_HOME}
 # If doing a regular local spark box.
 WORKDIR /srv/chronon
 

--- a/api/py/test/sample/teams.json
+++ b/api/py/test/sample/teams.json
@@ -5,7 +5,7 @@
         },
         "common_env": {
             "VERSION": "latest",
-            "SPARK_SUBMIT_PATH": "[TODO]/path/to/spark-submit",
+            "SPARK_SUBMIT_PATH": "/opt/spark/bin/spark-submit",
             "JOB_MODE": "local[*]",
             "HADOOP_DIR": "[STREAMING-TODO]/path/to/folder/containing",
             "CHRONON_ONLINE_CLASS": "[ONLINE-TODO]your.online.class",

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val scala213 = "2.13.6"
 lazy val spark2_4_0 = "2.4.0"
 lazy val spark3_1_1 = "3.1.1"
 lazy val spark3_2_1 = "3.2.1"
+lazy val spark3_5_3 = "3.5.3"
 lazy val tmp_warehouse = "/tmp/chronon/"
 
 ThisBuild / organization := "ai.chronon"
@@ -36,6 +37,9 @@ ThisBuild / developers := List(
   )
 )
 ThisBuild / assembly / test := {}
+
+val use_spark_3_5 = settingKey[Boolean]("Flag to build for 3.5")
+ThisBuild / use_spark_3_5 := false
 
 def buildTimestampSuffix = ";build.timestamp=" + new java.util.Date().getTime
 lazy val publishSettings = Seq(
@@ -92,17 +96,17 @@ lazy val root = (project in file("."))
 // Git related config
 git.useGitDescribe := true
 git.gitTagToVersionNumber := { tag: String => {
-    // Git plugin will automatically add SNAPSHOT for dirty workspaces so remove it to avoid duplication.
-    val versionStr = if (git.gitUncommittedChanges.value) version.value.replace("-SNAPSHOT", "") else version.value
-    val branchTag = git.gitCurrentBranch.value.replace("/", "-")
-    if (branchTag == "main" || branchTag == "master") {
-      // For main branches, we tag the packages as <package-name>-<build-version>
-      Some(s"${versionStr}")
-    } else {
-      // For user branches, we tag the packages as <package-name>-<user-branch>-<build-version>
-      Some(s"${branchTag}-${versionStr}")
-    }
+  // Git plugin will automatically add SNAPSHOT for dirty workspaces so remove it to avoid duplication.
+  val versionStr = if (git.gitUncommittedChanges.value) version.value.replace("-SNAPSHOT", "") else version.value
+  val branchTag = git.gitCurrentBranch.value.replace("/", "-")
+  if (branchTag == "main" || branchTag == "master") {
+    // For main branches, we tag the packages as <package-name>-<build-version>
+    Some(s"${versionStr}")
+  } else {
+    // For user branches, we tag the packages as <package-name>-<user-branch>-<build-version>
+    Some(s"${branchTag}-${versionStr}")
   }
+}
 }
 git.versionProperty := {
   val versionStr = version.value
@@ -117,11 +121,11 @@ git.versionProperty := {
 }
 
 /**
-  * Versions are look up from mvn central - so we are fitting for three configurations
-  * scala 11 + spark 2.4: https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.11/2.4.0
-  * scala 12 + spark 3.1.1: https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.12/3.1.1
-  * scala 13 + spark 3.2.1: https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.2.1
-  */
+ * Versions are look up from mvn central - so we are fitting for three configurations
+ * scala 11 + spark 2.4: https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.11/2.4.0
+ * scala 12 + spark 3.1.1: https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.12/3.1.1
+ * scala 13 + spark 3.2.1: https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.2.1
+ */
 val VersionMatrix: Map[String, VersionDependency] = Map(
   "spark-sql" -> VersionDependency(
     Seq(
@@ -131,6 +135,15 @@ val VersionMatrix: Map[String, VersionDependency] = Map(
     Some(spark2_4_0),
     Some(spark3_1_1),
     Some(spark3_2_1)
+  ),
+  "spark-sql-3-5" -> VersionDependency(
+    Seq(
+      "org.apache.spark" %% "spark-sql",
+      "org.apache.spark" %% "spark-core"
+    ),
+    Some(spark2_4_0),
+    Some(spark3_5_3),
+    Some(spark3_5_3)
   ),
   "spark-all" -> VersionDependency(
     Seq(
@@ -143,6 +156,18 @@ val VersionMatrix: Map[String, VersionDependency] = Map(
     Some(spark2_4_0),
     Some(spark3_1_1),
     Some(spark3_2_1)
+  ),
+  "spark-all-3-5" -> VersionDependency(
+    Seq(
+      "org.apache.spark" %% "spark-sql",
+      "org.apache.spark" %% "spark-hive",
+      "org.apache.spark" %% "spark-core",
+      "org.apache.spark" %% "spark-streaming",
+      "org.apache.spark" %% "spark-sql-kafka-0-10"
+    ),
+    Some(spark2_4_0),
+    Some(spark3_5_3),
+    Some(spark3_5_3)
   ),
   "scala-reflect" -> VersionDependency(
     Seq("org.scala-lang" % "scala-reflect"),
@@ -211,7 +236,7 @@ def fromMatrix(scalaVersion: String, modules: String*): Seq[ModuleID] =
       mod = module.replace("/provided", "")
     }
     assert(VersionMatrix.contains(mod),
-           s"Version matrix doesn't contain module: $mod, pick one of ${VersionMatrix.keys.toSeq}")
+      s"Version matrix doesn't contain module: $mod, pick one of ${VersionMatrix.keys.toSeq}")
     val result = VersionMatrix(mod).of(scalaVersion)
     if (provided) result.map(_ % "provided") else result
   }
@@ -275,10 +300,10 @@ releasePromptTask := {
   var wait = true
   while (wait) {
     println(s"""
-            |[WARNING] Scala artifacts have been published to the Sonatype staging.
-            |Please verify the Java builds are in order before proceeding with the Python API release.
-            |Python release is irreversible. So proceed with caution.
-            |""".stripMargin)
+               |[WARNING] Scala artifacts have been published to the Sonatype staging.
+               |Please verify the Java builds are in order before proceeding with the Python API release.
+               |Python release is irreversible. So proceed with caution.
+               |""".stripMargin)
     val userInput = StdIn.readLine(s"Do you want to continue with the release: (y)es (n)o ? ").trim.toLowerCase
     if (userInput == "yes" || userInput == "y") {
       println("Continuing with the Python API release..")
@@ -339,19 +364,19 @@ lazy val online_unshaded = (project in file("online"))
       "com.github.ben-manes.caffeine" % "caffeine" % "2.8.5"
     ),
     libraryDependencies ++= fromMatrix(scalaVersion.value,
-                                       "jackson",
-                                       "avro",
-                                       "spark-all/provided",
-                                       "scala-parallel-collections",
-                                       "netty-buffer")
+      "jackson",
+      "avro",
+      "spark-all/provided",
+      "scala-parallel-collections",
+      "netty-buffer")
   )
 
 
 def cleanSparkMeta(): Unit = {
   Folder.clean(file(".") / "spark" / "spark-warehouse*",
-               file(tmp_warehouse) / "spark-warehouse*",
-               file(".") / "spark" / "metastore_db*",
-               file(tmp_warehouse) / "metastore_db*")
+    file(tmp_warehouse) / "spark-warehouse*",
+    file(".") / "spark" / "metastore_db*",
+    file(tmp_warehouse) / "metastore_db*")
 }
 
 val sparkBaseSettings: Seq[Setting[_]] = Seq(
@@ -359,6 +384,20 @@ val sparkBaseSettings: Seq[Setting[_]] = Seq(
   assembly / artifact := {
     val art = (assembly / artifact).value
     art.withClassifier(Some("assembly"))
+  },
+  Compile / unmanagedSources := {
+    val sources = (Compile / unmanagedSources).value
+    val srcDir = (Compile / sourceDirectory).value
+
+    val spark_3_5_encoder = srcDir / "spark-3_5_plus" / "ai" / "chronon" / "spark" / "EncoderUtil.scala"
+    val spark_default_encoder = srcDir / "spark-default" / "ai" / "chronon" / "spark" / "EncoderUtil.scala"
+
+    val filteredSources = sources.filterNot(f =>
+      f.getAbsolutePath == spark_3_5_encoder.getAbsolutePath ||
+        f.getAbsolutePath == spark_default_encoder.getAbsolutePath
+    )
+
+    filteredSources :+ (if (use_spark_3_5.value) spark_3_5_encoder else spark_default_encoder)
   },
   mainClass in (Compile, run) := Some("ai.chronon.spark.Driver"),
   cleanFiles ++= Seq(file(tmp_warehouse)),
@@ -373,7 +412,10 @@ lazy val spark_uber = (project in file("spark"))
     sparkBaseSettings,
     version := git.versionProperty.value,
     crossScalaVersions := supportedVersions,
-    libraryDependencies ++= fromMatrix(scalaVersion.value, "jackson", "spark-all/provided", "delta-core/provided")
+    libraryDependencies ++= (if (use_spark_3_5.value)
+      fromMatrix(scalaVersion.value, "jackson", "spark-all-3-5/provided", "delta-core/provided")
+    else
+      fromMatrix(scalaVersion.value, "jackson", "spark-all/provided", "delta-core/provided"))
   )
 
 lazy val spark_embedded = (project in file("spark"))
@@ -382,7 +424,10 @@ lazy val spark_embedded = (project in file("spark"))
     sparkBaseSettings,
     version := git.versionProperty.value,
     crossScalaVersions := supportedVersions,
-    libraryDependencies ++= fromMatrix(scalaVersion.value, "spark-all", "delta-core"),
+    libraryDependencies ++= (if (use_spark_3_5.value)
+      fromMatrix(scalaVersion.value, "spark-all-3-5", "delta-core")
+    else
+      fromMatrix(scalaVersion.value, "spark-all", "delta-core")),
     target := target.value.toPath.resolveSibling("target-embedded").toFile,
     Test / test := {}
   )
@@ -393,10 +438,10 @@ lazy val flink = (project in file("flink"))
     publishSettings,
     crossScalaVersions := List(scala212),
     libraryDependencies ++= fromMatrix(scalaVersion.value,
-                                       "avro",
-                                       "spark-all/provided",
-                                       "scala-parallel-collections",
-                                       "flink")
+      "avro",
+      "spark-all/provided",
+      "scala-parallel-collections",
+      "flink")
   )
 
 lazy val service = (project in file("service"))

--- a/spark/src/main/spark-3_5_plus/ai/chronon/spark/EncoderUtil.scala
+++ b/spark/src/main/spark-3_5_plus/ai/chronon/spark/EncoderUtil.scala
@@ -1,0 +1,29 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.spark
+
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Encoder, Encoders, Row}
+
+import scala.collection.Seq
+
+object EncoderUtil {
+
+  def apply(structType: StructType): Encoder[Row] = Encoders.row(structType)
+
+}

--- a/spark/src/main/spark-default/ai/chronon/spark/EncoderUtil.scala
+++ b/spark/src/main/spark-default/ai/chronon/spark/EncoderUtil.scala
@@ -1,0 +1,27 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.spark
+
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Encoder, Row}
+
+object EncoderUtil {
+
+  def apply(structType: StructType): Encoder[Row] = RowEncoder(structType)
+
+}


### PR DESCRIPTION
This yoinks Spark 3.5.X support from an upstream without all of the bazel changes

Most of this is from an PR in Chronon's repo however some changes to the dockerfile and the sample are from me. I've validated that this works for at least backfills on Chronon's quickstart (yay chronon finally running for us!) -- note: i have not validated it with iceberg or anything like that, took an extremely light touch here

## How To Run
IMO this works best in Coder so i'd suggest that but it'll work on your ARM macos laptop as well. I'll leave the coder instructions here and ping me for instructions to run locally, they're pretty similar though.

Note: This assumes you're using Intellij with the Coder remote development environment. 
### Installing Deps
 Go to a directory where you don't mind downloading a tar to, then:

```sh
wget https://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz
tar -xzf thrift-0.13.0.tar.gz
cd thrift-0.13.0/
./bootstrap.sh
## We don't really need any language bindings, without all these options it'll try to build thrift for each language
## C++ is okay in my experience, the rest of these can cause compilation errors and we don't need them anyway
./configure --with-java=no --with-rust=no --with-go=no --with-erlang=no --with-nodejs=no --with-rs=no --with-swift=no --with-perl=no --with-python=no --with-ruby=no
sudo make
sudo make install
# thrift should be installed, run the next command to check to see if its working
thrift --version
# you should see: Thrift version 0.13.0
```

Now install some python dependencies by running `python3 -m pip install build setuptools wheel`

You should be good to go now.

### Setting Up The Repo for Discord Environments
1. Clone the repo
2. With Intellij, open up the remote directory, intellij should detect the SBT project automatically. If you have issues, go into project structure and ensure you're using Java JDK 11, more modern versions won't work
3. Open up the SBT shell
4. Run `set use_spark_3_5 := true` to configure it for spark 3.5.x
5. Run `package` to build
6. Run `assembly` to build the jar
7. Ensure that you have a jar under `spark/target-embedded/scala-2.12/` with SNAPSHOT in it, like `spark_embedded-assembly-spark-upgrade-0.0.87-SNAPSHOT.jar` — if your jar is named differently, replace the path at the top of the Dockerfile in the root directory of the repo

### Running the QuickStart Backfill
1. Build and run the image: `docker build -t temp . && docker run -it temp /bin/bash` -- its tagged as `temp` here. The rest of the commands should be ran inside the container
2. compile the quickstart training set: `compile.py --conf=joins/quickstart/training_set.py`
3. run `spark-shell -i scripts/data-loader.scala` to seed some data into the Hadoop FS -- you'll see some dataframes printed out with some fake data inside
4. run `USER=docker run.py --conf production/joins/quickstart/training_set.v1` — this will do the chronon job, you'll see some data printed out at the bottom once its done

if you wanna poke at the data a bit, run `spark-sql` to enter the spark sql repl then you can run
`SELECT user_id, quickstart_returns_v1_refund_amt_sum_30d, quickstart_purchases_v1_purchase_price_sum_14d, quickstart_users_v1_email_verified from default.quickstart_training_set_v1 limit 100;`

## TODO/Next Steps
- Try running with Iceberg in our monorepo environment
- Integrate with Verity
- Test Online w/ the quickstart mongodb
- Find a place to save the python distribution and the built jar for easy integration with our stuff
- BigQuery support

